### PR TITLE
Nick's patch targeted at Andrew's working branch

### DIFF
--- a/agent/bench-scripts/gold/pbench-dbench/test-00.txt
+++ b/agent/bench-scripts/gold/pbench-dbench/test-00.txt
@@ -1,61 +1,37 @@
 +++ Running test-00 pbench-dbench
-[debug][1900-01-01T00:00:00.000000] [pbench-dbench]processing options
-[debug][1900-01-01T00:00:00.000000] [pbench-dbench]what happened? [--]
-[debug][1900-01-01T00:00:00.000000] checking for dbench on client 127.0.0.1
-[debug][1900-01-01T00:00:00.000000] checking for dbench on client 127.0.0.1
 Starting iteration  (1 of 2)
 test sample 1 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[24]
 client[1-127.0.0.1]node[0]threads[24]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[24]
 client[2-127.0.0.1]node[1]threads[24]
 test sample 2 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[24]
 client[1-127.0.0.1]node[0]threads[24]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[24]
 client[2-127.0.0.1]node[1]threads[24]
 test sample 3 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[24]
 client[1-127.0.0.1]node[0]threads[24]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[24]
 client[2-127.0.0.1]node[1]threads[24]
 test sample 4 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[24]
 client[1-127.0.0.1]node[0]threads[24]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[24]
 client[2-127.0.0.1]node[1]threads[24]
 test sample 5 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[24]
 client[1-127.0.0.1]node[0]threads[24]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[24]
 client[2-127.0.0.1]node[1]threads[24]
 '######' Throughput-GiB_sec: 6.749179 6.749179 6.749179 6.749179 6.749179 average: 6.7492 stddev: 0.0000% closest-sample: 1
 Iteration 1-24thread complete (1 of 2), with 1 pass and 0 failures
 Starting iteration 1-24thread (2 of 2)
 test sample 1 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[48]
 client[1-127.0.0.1]node[0]threads[48]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[48]
 client[2-127.0.0.1]node[1]threads[48]
 test sample 2 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[48]
 client[1-127.0.0.1]node[0]threads[48]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[48]
 client[2-127.0.0.1]node[1]threads[48]
 test sample 3 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[48]
 client[1-127.0.0.1]node[0]threads[48]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[48]
 client[2-127.0.0.1]node[1]threads[48]
 test sample 4 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[48]
 client[1-127.0.0.1]node[0]threads[48]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[48]
 client[2-127.0.0.1]node[1]threads[48]
 test sample 5 of 5
-[debug][1900-01-01T00:00:00.000000] client[1-127.0.0.1]node[0]threads[48]
 client[1-127.0.0.1]node[0]threads[48]
-[debug][1900-01-01T00:00:00.000000] client[2-127.0.0.1]node[1]threads[48]
 client[2-127.0.0.1]node[1]threads[48]
 '######' Throughput-GiB_sec: 6.749179 6.749179 6.749179 6.749179 6.749179 average: 6.7492 stddev: 0.0000% closest-sample: 1
 Iteration 2-48thread complete (2 of 2), with 1 pass and 0 failures

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -140,7 +140,6 @@ _dump_logs
 _verify_output $res test-01 pbench-uperf
 res=$?
 let errs=$errs+$res
-exit
 _reset_state
 
 #


### PR DESCRIPTION
Delete spurious exit in bench-scripts/unittests - fix gold dbench output for DEBUG=0
