### PR TITLE
command line option for traffic direction not transferred correctly b…

### DIFF
--- a/agent/bench-scripts/pbench-trafficgen
+++ b/agent/bench-scripts/pbench-trafficgen
@@ -675,9 +675,9 @@ for rate in `echo $rates | sed -e s/,/" "/g`; do
 						log "Starting iteration[$iteration] ($count of $total_iterations)"
 						# Add any benchmark-iteration-specific options
 						if [  $traffic_direction == "unidirec" ]; then
-							iteration_opts=" --run-bidirec=0"
+							iteration_options=" --run-bidirec=0"
 						else
-							iteration_opts=" --run-bidirec=1"
+							iteration_options=" --run-bidirec=1"
 						fi
 						iteration_options="$iteration_options --max-loss-pct=$max_loss_pct"
 						iteration_options="$iteration_options --frame-size=$frame_size"


### PR DESCRIPTION
…etween pbench and binary search.  This resulted in only running bidirectional traffic