### PR TITLE
trafficgen-postprocess: avoid casting an integer to a string via infe…

### DIFF
--- a/agent/bench-scripts/postprocess/trafficgen-postprocess
+++ b/agent/bench-scripts/postprocess/trafficgen-postprocess
@@ -165,7 +165,7 @@ if ($json_result) {
 	my $perl_scalar = from_json( $json_text );
 	my $rx_port;
 	for my $tx_port (0, 1) {
-		if ( $tx_port eq 0 ) {
+		if ( $tx_port == 0 ) {
 			$rx_port = 1;
 		} else {
 			$rx_port = 0;


### PR DESCRIPTION
…rence of equality test

- When the JSON is rendered the 'tx_port' is rendered as a string if
  an "eq" is used but as an integer if a "==" is used.